### PR TITLE
Path instance_eval() a filename

### DIFF
--- a/lib/naginata/loader.rb
+++ b/lib/naginata/loader.rb
@@ -12,13 +12,14 @@ module Naginata
 
       def load_configuration
         # Load defaults.rb
-        instance_eval File.read(File.join(File.dirname(__FILE__), 'defaults.rb'))
+        default = File.join(File.dirname(__FILE__), 'defaults.rb')
+        instance_eval File.read(default), default
         # Load Naginatafile
         naginatafile_path = ::Naginata::Configuration.env.fetch(:naginatafile) || find_naginatafile
         if naginatafile_path.nil? or !File.file?(naginatafile_path)
           raise NaginatafileNotFound, 'Could not locate Naginatafile'
         else
-          instance_eval File.read naginatafile_path
+          instance_eval File.read(naginatafile_path), naginatafile_path
         end
       end
 


### PR DESCRIPTION
This prints better error message if users writes false settings in Naginatafile. Example: 

**previously**: path/to/naginata/lib/naginata/loader.rb:21:in `instance_eval': undefined local variable or method`typo' for Naginata::Loader:Class (NameError)
**now**: path/to/Naginatafile:2:in `load_configuration': undefined local variable or method`typo' for Naginata::Loader:Class (NameError)

Also, this fixes unworking `__FILE__` direction when users put `__FILE__` in Naginatafile.
